### PR TITLE
Remove PE config

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,16 +39,6 @@
     "message": "Good morning! :wave: The following are on rota this week:\n`Daily Scrum:` <<2>> - <<1>>\n`Green Flag:` <<3>>\n`Next Retro:` <<4>>\n\nFor any clashes between your <https://docs.google.com/spreadsheets/d/1Q2aBUo8IK5bh10qJEtwgDE3L42Ik4uK5JubX8XFNwrE/edit#gid=1102222716|planned holidays> and your rota days, please check with the team who can swap with you and update the rota <https://docs.google.com/spreadsheets/d/1T0cOPUfKsW6aK5Pswarku_bdYr6m73F0lRkVnO_cDJs/edit?usp=sharing|here>.\n"
 },
 {
-    "name": "Project Explorer",
-    "description": "The project explorer rota, posts to #team-dpc-etl-project-explorer",
-    "owner": "Mia",
-    "days-active": "YYYYY",
-    "spreadsheet": "1T0cOPUfKsW6aK5Pswarku_bdYr6m73F0lRkVnO_cDJs",
-    "sheet-id": "971719928",
-    "slack-channel": "C03K11K1XUM",
-    "message": "Good morning! :wave: The following are on rota this week:\n`Daily Scrum:` <<5>> - <<1>>\n`Green Flag:` <<6>>\n`Next Retro:` <<7>>\n\nUpdate rota <https://docs.google.com/spreadsheets/d/1T0cOPUfKsW6aK5Pswarku_bdYr6m73F0lRkVnO_cDJs/edit?usp=sharing|here>. "
-},
-{
     "name": "Designer Engagement",
     "description": "The designer rota, posts to #dpc-designer-team-engagement",
     "owner": "Abhi",


### PR DESCRIPTION
The project explorer team have now been merged into the Git team so we no longer require the rota to be published in the PE team channel.